### PR TITLE
Don't couple systems so tightly

### DIFF
--- a/editor_backend/editor_backend/tests.py
+++ b/editor_backend/editor_backend/tests.py
@@ -64,12 +64,11 @@ class URLEndpointTestCase(SimpleTestCase):
         self.assertEqual(200, response.status_code)
 
     def test_get_article_detail_view(self):
-        url = reverse('article', args=(-1,))
+        url = reverse('article', args=(1,))
 
         response = self.client.get(url)
 
-        # 500 if service does not have the asked-for resource, otherwise it'll pass
-        self.assertEqual(500, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_get_search_view(self):
         url = reverse('articles')


### PR DESCRIPTION
Makes sure that most request that try to connect to an external resource will gracefully fail and give some useful feedback to the user, as well as logs to the administrator, rather than Django raising a HTTP 500 for the failing requests. Also updates test to handle this new practice.
